### PR TITLE
Hotfix: 회원가입 실패 시 팝업창에서 메인화면으로 이동하는 현상 수정

### DIFF
--- a/src/app/(auth)/social-callback/page.tsx
+++ b/src/app/(auth)/social-callback/page.tsx
@@ -210,10 +210,10 @@ function SocialCallbackContent() {
           </h2>
           <p className="text-gray-600 mb-6">{error}</p>
           <button
-            onClick={() => router.push("/")}
+            onClick={handleCancel}
             className="px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-semibold rounded-lg transition-all duration-200"
           >
-            메인으로 이동
+            닫기
           </button>
         </div>
       </div>


### PR DESCRIPTION
 - 회원가입 실패 시 팝업창의 버튼을 "닫기"로 변경
 - 닫기를 누르면 팝업창 닫고 원래 머무르던 페이지에 머무를 수 있도록 구현